### PR TITLE
Fix unhandled exception for FindCommand

### DIFF
--- a/src/main/java/seedu/ezdo/model/ModelManager.java
+++ b/src/main/java/seedu/ezdo/model/ModelManager.java
@@ -280,16 +280,22 @@ public class ModelManager extends ComponentManager implements Model {
 
             String taskStartDate = task.getStartDate().toString();
             String taskDueDate = task.getDueDate().toString();
+            String taskPriority = task.getPriority().toString();
 
             Set<String> taskTagStringSet = convertToTagStringSet(task.getTags().toSet());
+            boolean startDateExist = (taskStartDate.length() != 0);
+            boolean dueDateExist = (taskDueDate.length() != 0);
+            boolean priorityExist = (taskPriority.length() != 0);
+
             return (nameKeyWords.contains("") || nameKeyWords.stream()
                     .allMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().fullName, keyword)))
                     && !task.getDone()
-                    && (!priority.isPresent() || task.getPriority().toString().equals(priority.get().toString()))
-                    && (!startDate.isPresent() || (taskStartDate.length() != 0)
-                            && taskStartDate.substring(0, 9).equals(startDate.get().toString().substring(0, 9)))
-                    && (!dueDate.isPresent() || (taskDueDate.length() != 0)
-                            && taskDueDate.substring(0, 9).equals(dueDate.get().toString().substring(0, 9)))
+                    && (!priority.isPresent() || (priority.get().toString().equals("") && priorityExist) || (priorityExist
+                            && task.getPriority().toString().equals(priority.get().toString())))
+                    && (!startDate.isPresent() || (startDate.get().toString().equals("") && startDateExist) || (startDateExist
+                            && taskStartDate.substring(0, 9).equals(startDate.get().toString().substring(0, 9))))
+                    && (!dueDate.isPresent() || (dueDate.get().toString().equals("") && dueDateExist) || (dueDateExist
+                            && taskDueDate.substring(0, 9).equals(dueDate.get().toString().substring(0, 9))))
                     && (taskTagStringSet.containsAll(tags));
 
         }

--- a/src/main/java/seedu/ezdo/model/ModelManager.java
+++ b/src/main/java/seedu/ezdo/model/ModelManager.java
@@ -290,10 +290,11 @@ public class ModelManager extends ComponentManager implements Model {
             return (nameKeyWords.contains("") || nameKeyWords.stream()
                     .allMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().fullName, keyword)))
                     && !task.getDone()
-                    && (!priority.isPresent() || (priority.get().toString().equals("") && priorityExist) || (priorityExist
-                            && task.getPriority().toString().equals(priority.get().toString())))
-                    && (!startDate.isPresent() || (startDate.get().toString().equals("") && startDateExist) || (startDateExist
-                            && taskStartDate.substring(0, 9).equals(startDate.get().toString().substring(0, 9))))
+                    && (!priority.isPresent() || (priority.get().toString().equals("") && priorityExist)
+                            || (priorityExist && task.getPriority().toString().equals(priority.get().toString())))
+                    && (!startDate.isPresent() || (startDate.get().toString().equals("") && startDateExist)
+                            || (startDateExist
+                                    && taskStartDate.substring(0, 9).equals(startDate.get().toString().substring(0, 9))))
                     && (!dueDate.isPresent() || (dueDate.get().toString().equals("") && dueDateExist) || (dueDateExist
                             && taskDueDate.substring(0, 9).equals(dueDate.get().toString().substring(0, 9))))
                     && (taskTagStringSet.containsAll(tags));

--- a/src/main/java/seedu/ezdo/model/ModelManager.java
+++ b/src/main/java/seedu/ezdo/model/ModelManager.java
@@ -293,8 +293,8 @@ public class ModelManager extends ComponentManager implements Model {
                     && (!priority.isPresent() || (priority.get().toString().equals("") && priorityExist)
                             || (priorityExist && task.getPriority().toString().equals(priority.get().toString())))
                     && (!startDate.isPresent() || (startDate.get().toString().equals("") && startDateExist)
-                            || (startDateExist
-                                    && taskStartDate.substring(0, 9).equals(startDate.get().toString().substring(0, 9))))
+                            || (startDateExist && taskStartDate.substring(0, 9).equals
+                                    (startDate.get().toString().substring(0, 9))))
                     && (!dueDate.isPresent() || (dueDate.get().toString().equals("") && dueDateExist) || (dueDateExist
                             && taskDueDate.substring(0, 9).equals(dueDate.get().toString().substring(0, 9))))
                     && (taskTagStringSet.containsAll(tags));

--- a/src/test/java/guitests/FindCommandTest.java
+++ b/src/test/java/guitests/FindCommandTest.java
@@ -19,15 +19,15 @@ public class FindCommandTest extends EzDoGuiTest {
         assertFindResult("find Meier", td.benson, td.daniel); // multiple results
         assertFindResult("find p/1", td.alice, td.benson);
         assertFindResult("find s/11/11/2015", td.benson);
-        assertFindResult("find d/04/14/2016", td.daniel);
+        assertFindResult("find d/14/04/2016", td.daniel);
         assertFindResult("find t/owesMoney", td.benson);
         assertFindResult("find Meier p/1", td.benson);
         assertFindResult("find Meier p/1 s/11/11/2015", td.benson);
         assertFindResult("find Meier p/1 s/11th Nov 2015", td.benson);
         assertFindResult("find Meier p/1 s/Nov 11th 2015", td.benson);
-        assertFindResult("find Meier p/1 s/11-11-2015 d/02/12/2017 t/owesMoney t/friends", td.benson);
+        assertFindResult("find Meier p/1 s/11-11-2015 d/12/02/2017 t/owesMoney t/friends", td.benson);
         assertFindResult("find p/2 d/april 14th 2016", td.daniel);
-        assertFindResult("find p/2 d/04/14/2016", td.daniel);
+        assertFindResult("find p/2 d/14/04/2016", td.daniel);
         assertFindResult("find p/1", td.alice, td.benson);
 
         //find after deleting one result


### PR DESCRIPTION
If no fields are indicated after a prefix, then the find command will return all tasks with that prefix field.
E.g 'find s/' returns all tasks with start dates; 'find p/' returns all tasks with priority