### PR TITLE
Change parsing for search dates and improve search options

### DIFF
--- a/src/main/java/seedu/ezdo/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/ezdo/logic/commands/FindCommand.java
@@ -16,18 +16,24 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n" + "Example: " + COMMAND_WORD + " buy milk clean p/3";
 
     private final ArrayList<Object> listToCompare;
-    private final boolean searchByStartDate;
-    private final boolean searchByDueDate;
+    private final boolean searchBeforeStartDate;
+    private final boolean searchBeforeDueDate;
+    private final boolean searchAfterStartDate;
+    private final boolean searchAfterDueDate;
 
-    public FindCommand(ArrayList<Object> listToCompare, boolean searchByStartDate, boolean searchByDueDate) {
+    public FindCommand(ArrayList<Object> listToCompare, boolean searchBeforeStartDate, boolean searchBeforeDueDate,
+                       boolean searchAfterStartDate, boolean searchAfterDueDate) {
         this.listToCompare = listToCompare;
-        this.searchByStartDate = searchByStartDate;
-        this.searchByDueDate = searchByDueDate;
+        this.searchBeforeStartDate = searchBeforeStartDate;
+        this.searchBeforeDueDate = searchBeforeDueDate;
+        this.searchAfterStartDate = searchAfterStartDate;
+        this.searchAfterDueDate = searchAfterDueDate;
     }
 
     @Override
     public CommandResult execute() {
-        model.updateFilteredTaskList(listToCompare, searchByStartDate, searchByDueDate);
+        model.updateFilteredTaskList(listToCompare, searchBeforeStartDate,
+                searchBeforeDueDate, searchAfterStartDate, searchAfterDueDate);
         return new CommandResult(getMessageForTaskListShownSummary(model.getFilteredTaskList().size()));
     }
 

--- a/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
@@ -110,11 +110,11 @@ public class FindCommandParser implements CommandParser {
             return false;
         } else {
             String taskDateString = taskDate.get();
-            if (taskDateString.length() < 3) {
+            if (taskDateString.length() < 6) {
                 return false;
             } else {
-                String prefixToCompare = "by/";
-                String byPrefix = taskDateString.substring(0, 3);
+                String prefixToCompare = "before";
+                String byPrefix = taskDateString.substring(0, 6);
                 return byPrefix.equals(prefixToCompare);
             }
         }

--- a/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
@@ -50,8 +50,10 @@ public class FindCommandParser implements CommandParser {
         Optional<TaskDate> findStartDate = null;
         Optional<TaskDate> findDueDate = null;
         Set<String> findTags;
-        boolean searchByStartDate = false;
-        boolean searchByDueDate = false;
+        boolean searchBeforeStartDate = false;
+        boolean searchBeforeDueDate = false;
+        boolean searchAfterStartDate = false;
+        boolean searchAfterDueDate = false;
 
         try {
 
@@ -61,12 +63,22 @@ public class FindCommandParser implements CommandParser {
 
             if (isFindBefore(optionalStartDate)) {
                 optionalStartDate = parseFindBefore(optionalStartDate);
-                searchByStartDate = true;
+                searchBeforeStartDate = true;
             }
 
             if (isFindBefore(optionalDueDate)) {
                 optionalDueDate = parseFindBefore(optionalDueDate);
-                searchByDueDate = true;
+                searchBeforeDueDate = true;
+            }
+
+            if (isFindAfter(optionalStartDate)) {
+                optionalDueDate = parseFindAfter(optionalStartDate);
+                searchAfterDueDate = true;
+            }
+
+            if (isFindAfter(optionalDueDate)) {
+                optionalDueDate = parseFindAfter(optionalDueDate);
+                searchAfterDueDate = true;
             }
 
             findStartDate = ParserUtil.parseStartDate(optionalStartDate, isFind);
@@ -84,7 +96,8 @@ public class FindCommandParser implements CommandParser {
         listToCompare.add(findStartDate);
         listToCompare.add(findDueDate);
         listToCompare.add(findTags);
-        return new FindCommand(listToCompare, searchByStartDate, searchByDueDate);
+        return new FindCommand(listToCompare, searchBeforeStartDate, searchBeforeDueDate,
+                               searchAfterStartDate, searchAfterDueDate);
     }
 
     private Optional<String> getOptionalValue(ArgumentTokenizer tokenizer, Prefix prefix) {
@@ -100,7 +113,15 @@ public class FindCommandParser implements CommandParser {
     private Optional<String> parseFindBefore(Optional<String> taskDate) {
         Optional<String> optionalDate;
         String taskDateString = taskDate.get();
-        String commandString = taskDateString.substring(3, taskDateString.length()).trim();
+        String commandString = taskDateString.substring(7, taskDateString.length()).trim();
+        optionalDate = Optional.of(commandString);
+        return optionalDate;
+    }
+
+    private Optional<String> parseFindAfter(Optional<String> taskDate) {
+        Optional<String> optionalDate;
+        String taskDateString = taskDate.get();
+        String commandString = taskDateString.substring(6, taskDateString.length()).trim();
         optionalDate = Optional.of(commandString);
         return optionalDate;
     }
@@ -115,6 +136,21 @@ public class FindCommandParser implements CommandParser {
             } else {
                 String prefixToCompare = "before";
                 String byPrefix = taskDateString.substring(0, 6);
+                return byPrefix.equals(prefixToCompare);
+            }
+        }
+    }
+
+    private boolean isFindAfter(Optional<String> taskDate) {
+        if (!taskDate.isPresent()) {
+            return false;
+        } else {
+            String taskDateString = taskDate.get();
+            if (taskDateString.length() < 5) {
+                return false;
+            } else {
+                String prefixToCompare = "after";
+                String byPrefix = taskDateString.substring(0, 5);
                 return byPrefix.equals(prefixToCompare);
             }
         }

--- a/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
@@ -72,8 +72,8 @@ public class FindCommandParser implements CommandParser {
             }
 
             if (isFindAfter(optionalStartDate)) {
-                optionalDueDate = parseFindAfter(optionalStartDate);
-                searchAfterDueDate = true;
+                optionalStartDate = parseFindAfter(optionalStartDate);
+                searchAfterStartDate = true;
             }
 
             if (isFindAfter(optionalDueDate)) {
@@ -113,7 +113,7 @@ public class FindCommandParser implements CommandParser {
     private Optional<String> parseFindBefore(Optional<String> taskDate) {
         Optional<String> optionalDate;
         String taskDateString = taskDate.get();
-        String commandString = taskDateString.substring(7, taskDateString.length()).trim();
+        String commandString = taskDateString.substring(6, taskDateString.length()).trim();
         optionalDate = Optional.of(commandString);
         return optionalDate;
     }
@@ -121,7 +121,8 @@ public class FindCommandParser implements CommandParser {
     private Optional<String> parseFindAfter(Optional<String> taskDate) {
         Optional<String> optionalDate;
         String taskDateString = taskDate.get();
-        String commandString = taskDateString.substring(6, taskDateString.length()).trim();
+        String commandString = taskDateString.substring(5, taskDateString.length()).trim();
+        System.out.println(commandString);
         optionalDate = Optional.of(commandString);
         return optionalDate;
     }
@@ -131,7 +132,7 @@ public class FindCommandParser implements CommandParser {
             return false;
         } else {
             String taskDateString = taskDate.get();
-            if (taskDateString.length() < 6) {
+            if (taskDateString.length() <= 6) {
                 return false;
             } else {
                 String prefixToCompare = "before";
@@ -146,7 +147,7 @@ public class FindCommandParser implements CommandParser {
             return false;
         } else {
             String taskDateString = taskDate.get();
-            if (taskDateString.length() < 5) {
+            if (taskDateString.length() <= 5) {
                 return false;
             } else {
                 String prefixToCompare = "after";

--- a/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/ezdo/logic/parser/FindCommandParser.java
@@ -59,13 +59,13 @@ public class FindCommandParser implements CommandParser {
             Optional<String> optionalStartDate = getOptionalValue(argsTokenizer, PREFIX_STARTDATE);
             Optional<String> optionalDueDate = getOptionalValue(argsTokenizer, PREFIX_DUEDATE);
 
-            if (isFindBy(optionalStartDate)) {
-                optionalStartDate = parseFindBy(optionalStartDate);
+            if (isFindBefore(optionalStartDate)) {
+                optionalStartDate = parseFindBefore(optionalStartDate);
                 searchByStartDate = true;
             }
 
-            if (isFindBy(optionalDueDate)) {
-                optionalDueDate = parseFindBy(optionalDueDate);
+            if (isFindBefore(optionalDueDate)) {
+                optionalDueDate = parseFindBefore(optionalDueDate);
                 searchByDueDate = true;
             }
 
@@ -97,7 +97,7 @@ public class FindCommandParser implements CommandParser {
         return optionalString;
     }
 
-    private Optional<String> parseFindBy (Optional<String> taskDate) {
+    private Optional<String> parseFindBefore(Optional<String> taskDate) {
         Optional<String> optionalDate;
         String taskDateString = taskDate.get();
         String commandString = taskDateString.substring(3, taskDateString.length()).trim();
@@ -105,7 +105,7 @@ public class FindCommandParser implements CommandParser {
         return optionalDate;
     }
 
-    private boolean isFindBy(Optional<String> taskDate) {
+    private boolean isFindBefore(Optional<String> taskDate) {
         if (!taskDate.isPresent()) {
             return false;
         } else {

--- a/src/main/java/seedu/ezdo/model/Model.java
+++ b/src/main/java/seedu/ezdo/model/Model.java
@@ -72,7 +72,8 @@ public interface Model {
     void updateFilteredListToShowAll();
 
     /** Updates the filter of the filtered task list to filter by multiple fields*/
-    void updateFilteredTaskList(ArrayList<Object> listToCompare, boolean searchByStartDate, boolean searchByDueDate);
+    void updateFilteredTaskList(ArrayList<Object> listToCompare, boolean searchBeforeStartDate,
+            boolean searchBeforeDueDate, boolean searchAfterStartDate, boolean searchAfterDueDate);
 
     /** Updates the filter of the filtered task list to show done tasks*/
     void updateFilteredDoneList();

--- a/src/main/java/seedu/ezdo/model/ModelManager.java
+++ b/src/main/java/seedu/ezdo/model/ModelManager.java
@@ -177,8 +177,10 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
-    public void updateFilteredTaskList(ArrayList<Object> listToCompare, boolean startBy, boolean dueBy) {
-        updateFilteredTaskList(new PredicateExpression(new NameQualifier(listToCompare, startBy, dueBy)));
+    public void updateFilteredTaskList(ArrayList<Object> listToCompare, boolean startBefore,
+            boolean dueBefore, boolean startAfter, boolean dueAfter) {
+        updateFilteredTaskList(new PredicateExpression(new NameQualifier(listToCompare,
+                startBefore, dueBefore, startAfter, dueAfter)));
     }
 
     @Override
@@ -274,17 +276,22 @@ public class ModelManager extends ComponentManager implements Model {
         private Optional<StartDate> startDate;
         private Optional<DueDate> dueDate;
         private Set<String> tags;
-        private boolean startBy;
-        private boolean dueBy;
+        private boolean startBefore;
+        private boolean dueBefore;
+        private boolean startAfter;
+        private boolean dueAfter;
 
-        NameQualifier(ArrayList<Object> listToCompare, boolean startBy, boolean dueBy) {
+        NameQualifier(ArrayList<Object> listToCompare, boolean startBefore,
+                boolean dueBefore, boolean startAfter, boolean dueAfter) {
             this.nameKeyWords = (Set<String>) listToCompare.get(0);
             this.priority = (Optional<Priority>) listToCompare.get(1);
             this.startDate = (Optional<StartDate>) listToCompare.get(2);
             this.dueDate = (Optional<DueDate>) listToCompare.get(3);
             this.tags = (Set<String>) listToCompare.get(4);
-            this.startBy = startBy;
-            this.dueBy = dueBy;
+            this.startBefore = startBefore;
+            this.dueBefore = dueBefore;
+            this.startAfter = startAfter;
+            this.dueAfter = dueAfter;
         }
 
         @Override
@@ -296,9 +303,9 @@ public class ModelManager extends ComponentManager implements Model {
                     .allMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().fullName, keyword)))
                     && !task.getDone()
                     && comparePriority(task.getPriority())
-                    && ((!startBy && compareStartDate(task.getStartDate()))
-                            || (startBy && compareByStart(task.getStartDate())))
-                    && ((!dueBy && compareDueDate(task.getDueDate())) || (dueBy && compareByDue(task.getDueDate())))
+                    && ((!startBefore && compareStartDate(task.getStartDate()))
+                            || (startBefore && compareBeforeStart(task.getStartDate())))
+                    && ((!dueBefore && compareDueDate(task.getDueDate())) || (dueBefore && compareBeforeDue(task.getDueDate())))
                     && (taskTagStringSet.containsAll(tags));
 
         }
@@ -348,7 +355,7 @@ public class ModelManager extends ComponentManager implements Model {
                        (dueDate.get().toString().substring(0, 10))));
         }
 
-        private boolean compareByStart(TaskDate taskStartDate) {
+        private boolean compareBeforeStart(TaskDate taskStartDate) {
             String taskStartDateString = taskStartDate.toString();
             boolean taskStartDateExist = (taskStartDateString.length() != 0);
 
@@ -356,7 +363,7 @@ public class ModelManager extends ComponentManager implements Model {
                     || (taskStartDateExist && comesBefore(startDate.get().toString(), taskStartDateString)));
         }
 
-        private boolean compareByDue(TaskDate taskDueDate) {
+        private boolean compareBeforeDue(TaskDate taskDueDate) {
             String taskDueDateString = taskDueDate.toString();
             boolean taskDueDateExist = (taskDueDateString.length() != 0);
 

--- a/src/main/java/seedu/ezdo/model/ModelManager.java
+++ b/src/main/java/seedu/ezdo/model/ModelManager.java
@@ -292,6 +292,7 @@ public class ModelManager extends ComponentManager implements Model {
             this.dueBefore = dueBefore;
             this.startAfter = startAfter;
             this.dueAfter = dueAfter;
+
         }
 
         @Override
@@ -303,9 +304,12 @@ public class ModelManager extends ComponentManager implements Model {
                     .allMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getName().fullName, keyword)))
                     && !task.getDone()
                     && comparePriority(task.getPriority())
-                    && ((!startBefore && compareStartDate(task.getStartDate()))
-                            || (startBefore && compareBeforeStart(task.getStartDate())))
-                    && ((!dueBefore && compareDueDate(task.getDueDate())) || (dueBefore && compareBeforeDue(task.getDueDate())))
+                    && (((!startBefore && !startAfter) && compareStartDate(task.getStartDate()))
+                            || (startBefore && compareBeforeStart(task.getStartDate()))
+                            || (startAfter && compareAfterStart(task.getStartDate())))
+                    && (((!dueBefore && !dueAfter) && compareDueDate(task.getDueDate()))
+                            || (dueBefore && compareBeforeDue(task.getDueDate()))
+                            || (dueAfter && compareAfterDue(task.getDueDate())))
                     && (taskTagStringSet.containsAll(tags));
 
         }
@@ -369,6 +373,22 @@ public class ModelManager extends ComponentManager implements Model {
 
             return (!dueDate.isPresent() || (dueDate.get().toString().equals("") && taskDueDateExist)
                     || (taskDueDateExist && comesBefore(dueDate.get().toString(), taskDueDateString)));
+        }
+
+        private boolean compareAfterStart(TaskDate taskStartDate) {
+            String taskStartDateString = taskStartDate.toString();
+            boolean taskStartDateExist = (taskStartDateString.length() != 0);
+
+            return (!startDate.isPresent() || (startDate.get().toString().equals("") && taskStartDateExist)
+                    || (taskStartDateExist && comesBefore(taskStartDateString, startDate.get().toString())));
+        }
+
+        private boolean compareAfterDue(TaskDate taskDueDate) {
+            String taskDueDateString = taskDueDate.toString();
+            boolean taskDueDateExist = (taskDueDateString.length() != 0);
+
+            return (!dueDate.isPresent() || (dueDate.get().toString().equals("") && taskDueDateExist)
+                    || (taskDueDateExist && comesBefore(taskDueDateString, dueDate.get().toString())));
         }
 
         private boolean comesBefore(String givenDate, String taskDate) {

--- a/src/test/java/guitests/FindCommandTest.java
+++ b/src/test/java/guitests/FindCommandTest.java
@@ -19,9 +19,11 @@ public class FindCommandTest extends EzDoGuiTest {
         assertFindResult("find Meier", td.benson, td.daniel); // multiple results
         assertFindResult("find p/1", td.alice, td.benson);
         assertFindResult("find s/11/11/2015", td.benson);
-        assertFindResult("find s/by/30/12/2012", td.daniel, td.elle, td.george);
+        assertFindResult("find s/before 30/12/2012", td.daniel, td.elle, td.george);
+        assertFindResult("find s/after 01/12/2015", td.alice, td.fiona);
         assertFindResult("find d/14/04/2016", td.daniel);
-        assertFindResult("find d/by/30/12/2014", td.carl);
+        assertFindResult("find d/before 30/12/2014", td.carl);
+        assertFindResult("find d/after 30/12/2016", td.alice, td.benson);
         assertFindResult("find t/owesMoney", td.benson);
         assertFindResult("find Meier p/1", td.benson);
         assertFindResult("find Meier p/1 s/11/11/2015", td.benson);


### PR DESCRIPTION
Changed a few things about finding dates:
- 'find s/before 10/10/2017' returns all tasks with start date before 10/10/2017
- 'find d/after 10/10/2017' returns all tasks with due dates after 10/10/2017

Can use different combination to hone in on certain dates
e.g 'find s/before 10/10/2017 d/after 12/12/2018'