### PR TITLE
Add logback dependency for Natty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ allprojects {
         testCompile 'org.jmockit:jmockit:1.31'
         testCompile "org.powermock:powermock-api-mockito:1.6.6"
         compile group: 'org.powermock', name: 'powermock-api-support', version: '1.6.6'
+        compile group: 'ch.qos.logback', name:'logback-classic', version: '1.2.2'
         testCompile "org.powermock:powermock-module-junit4:1.6.6"
         testCompile "org.mockito:mockito-core:1.+"
         testCompile "junit:junit:$junitVersion"


### PR DESCRIPTION
Resolves error messages shown below:

![capture](https://cloud.githubusercontent.com/assets/20759853/24480132/57a79f76-1515-11e7-9a7a-cff1bc0dcbaa.PNG)


If Natty is used at any point in time, it will display this logback message:

![capture1](https://cloud.githubusercontent.com/assets/20759853/24480191/94a36428-1515-11e7-851a-963e4bfda851.PNG)

